### PR TITLE
making builds work on macos

### DIFF
--- a/src/atlas.cpp
+++ b/src/atlas.cpp
@@ -1,6 +1,10 @@
 #include "atlas.hpp"
 
-#include <glad/gl.h>
+#ifdef __APPLE__
+  #define GL_SILENCE_DEPRECATION
+#else
+  #include <glad/gl.h>
+#endif
 #include <external/glfw/include/GLFW/glfw3.h>
 
 #include <algorithm>

--- a/src/ssaa_window.cpp
+++ b/src/ssaa_window.cpp
@@ -12,7 +12,11 @@ float inverse_aspect_ratio;
 bool resized;
 
 SSAAWindow::SSAAWindow(u32 x, u32 y, float scale, std::string title) {
-  window = rl::Window(x, y, title, true);
+  #ifdef __APPLE__
+    window = rl::Window(x, y, title);
+  #else
+    window = rl::Window(x, y, title, true);
+  #endif
   window.SetState(FLAG_VSYNC_HINT | FLAG_WINDOW_RESIZABLE);
   // just in case vsync was forcefully disabled, don't want to cook CPU
   SetTargetFPS(240);


### PR DESCRIPTION
Attempted to build for macos and ran into some `gl.h` issues where the linker wasn't able to find them.
Commenting it out seems to work since clang can find the functions if `gl.h` isn't included (I'm really not too sure why, think it has to do with mac bundled entry points?). Managed to build on both x86_64 and M1 arm64 macos. Can also provide a zip of the build for x86
I know #ifdef isn't really the best solution - willing to refactor to multiple files or whatever solution you prefer. Also this should not have any affect for the windows / linux build, but I haven't tested that yet.